### PR TITLE
Update LXML to version 4.6.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.6.3" %}
+{% set version = "4.6.4" %}
 
 package:
   name: lxml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/l/lxml/lxml-{{ version }}.tar.gz
-  sha256: 39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468
+  sha256: daf9bd1fee31f1c7a5928b3e1059e09a8d683ea58fb3ffc773b6c88cb8d1399c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,14 +14,12 @@ build:
 
 requirements:
   build:
-    - python
-    - cython
     - {{ compiler('c') }}
   host:
     - libxml2
     - python
     - pip
-    - cython
+    - cython >=0.29.7
     - libxslt
   run:
     - python
@@ -32,6 +30,9 @@ test:
     - lxml
     - lxml.etree
     - lxml.objectify
+    - lxml.includes
+    - lxml.html
+    - lxml.isoschematron
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
 
 requirements:
   build:
+    - python
+    - cython
     - {{ compiler('c') }}
   host:
     - libxml2


### PR DESCRIPTION
  lxml 4.6.4
1. check the upstream
    https://github.com/lxml/lxml/tree/lxml-4.6.4

2. check the pinnings
    https://github.com/lxml/lxml/blob/lxml-4.6.4/versioninfo.py
    https://github.com/lxml/lxml/blob/lxml-4.6.4/update-error-constants.py
    https://github.com/lxml/lxml/blob/lxml-4.6.4/tox.ini
    https://github.com/lxml/lxml/blob/lxml-4.6.4/setup.py
    https://github.com/lxml/lxml/blob/lxml-4.6.4/requirements.txt

3. check the changelogs
    https://github.com/lxml/lxml/blob/lxml-4.6.4/CHANGES.txt
    
4. additional research
    https://github.com/conda-forge/lxml-feedstock/issues

    There is an existing open issue in conda-forge

5. verify dev_url
    https://github.com/lxml/lxml

6. verify doc_url
    http://lxml.de/index.html#documentation

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `lxml` package version `4.6.4` the folowing
command was used:
`conda build lxml-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `lxml` to version `4.6.4`

