### PR TITLE
lxml 4.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.6.4" %}
+{% set version = "4.7.1" %}
 
 package:
   name: lxml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/l/lxml/lxml-{{ version }}.tar.gz
-  sha256: daf9bd1fee31f1c7a5928b3e1059e09a8d683ea58fb3ffc773b6c88cb8d1399c
+  sha256: a1613838aa6b89af4ba10a0f3a972836128801ed008078f8c1244e65958f1b24
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,14 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libxml2 >=2.9.2
     - python
-    - pip
     - cython >=0.29.7
+    # see https://github.com/lxml/lxml/blob/master/INSTALL.txt
+    - libxml2 >=2.9.2
     - libxslt
+    - pip
+    - setuptools
+    - wheel
   run:
     - python
     - libxslt >=1.1.28

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,14 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libxml2
+    - libxml2 >=2.9.2
     - python
     - pip
     - cython >=0.29.7
     - libxslt
   run:
     - python
-    - libxslt
+    - libxslt >=1.1.28
 
 test:
   imports:


### PR DESCRIPTION
Update lxml to 4.7.1

Version change: bump version number from 4.6.4 to 4.7.1
Bug Tracker: new open issues https://github.com/lxml/lxml/issues
Github releases:  https://github.com/lxml/lxml/releases
Upstream Changelog: https://github.com/lxml/lxml/blob/master/CHANGES.txt
Upstream setup file https://github.com/lxml/lxml/blob/lxml-4.7.1/setup.py and https://github.com/lxml/lxml/blob/lxml-4.7.1/requirements.txt
Installation: https://github.com/lxml/lxml/blob/master/INSTALL.txt

The package lxml is mentioned inside the packages:
cssselect | datasets | et_xmlfile |  moto | networkx | pandas-datareader | parsel | pyquery | scrapy | xmlsec |

Actions:
1. Update dependencies
2. Add missing packages `setuptools`, `wheel`

Result:
- all-succeeded