### PR TITLE
lxml 4.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.7.1" %}
+{% set version = "4.8.0" %}
 
 package:
   name: lxml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/l/lxml/lxml-{{ version }}.tar.gz
-  sha256: a1613838aa6b89af4ba10a0f3a972836128801ed008078f8c1244e65958f1b24
+  sha256: f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -42,7 +42,7 @@ test:
     - pip check
 
 about:
-  home: http://lxml.de/
+  home: https://lxml.de/
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   license_file: LICENSES.txt
   summary: Pythonic binding for the C libraries libxml2 and libxslt.
@@ -51,7 +51,7 @@ about:
     libxslt. It is unique in that it combines the speed and XML feature
     completeness of these libraries with the simplicity of a native Python API,
     mostly compatible but superior to the well-known ElementTree API.
-  doc_url: http://lxml.de/index.html#documentation
+  doc_url: https://lxml.de/index.html#documentation
   dev_url: https://github.com/lxml/lxml
   doc_source_url: https://github.com/lxml/lxml/tree/master/doc
 


### PR DESCRIPTION
Update lxml to 4.8.0. This version will be with python 3.10 support

Version change: bump version number from 4.7.1 to 4.8.0
Bug Tracker: new open issues https://github.com/lxml/lxml/issues
Upstream Changelog: https://github.com/lxml/lxml/blob/master/CHANGES.txt
Upstream setup file https://github.com/lxml/lxml/blob/lxml-4.8.0/setup.py and https://github.com/lxml/lxml/blob/lxml-4.8.0/requirements.txt
Installation: https://github.com/lxml/lxml/blob/master/INSTALL.txt

The package lxml is mentioned inside the packages:
cssselect | datasets | et_xmlfile |  moto | networkx | pandas-datareader | parsel | pyquery | scrapy | xmlsec |

Actions:
1. Reset build number to 0
2. Fix home and doc urls with HTTPS

Result:
- all-succeeded