### PR TITLE
Py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,3 @@
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
-%PYTHON% setup.py install --with-cython
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,20 @@
+{% set name = "lxml" %}
 {% set version = "5.3.0" %}
 
 package:
-  name: lxml
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/l/lxml/lxml-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/l/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     # pkg-config is needed to locate %PREFIX%\Library\include\libxml2 on Windows.
     - pkg-config  # [win]
@@ -24,8 +26,8 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - libiconv  # [win]
-    - zlib      # [win]
+    - libiconv {{ libiconv }} # [win]
+    - zlib {{ zlib }}         # [win]
   run:
     - python
     - libxml2 # has run exports
@@ -45,7 +47,7 @@ test:
     - pip check
 
 about:
-  home: https://lxml.de/
+  home: https://lxml.de
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   license_family: Other
   license_file: LICENSES.txt


### PR DESCRIPTION
Rebuild for py314 - needed by [PKG-10916](https://anaconda.atlassian.net/browse/PKG-10916)

- bump build number
- satisfy linter
- add py314
- Fix Windows script

The build with cython fails. There's ABI incompatibility with libxml2:
- https://github.com/xmlsec/python-xmlsec/issues/400
- https://github.com/xmlsec/python-xmlsec/issues/356

Hence, cython build is off in `bld.bat`

[PKG-10916]: https://anaconda.atlassian.net/browse/PKG-10916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ