### PR TITLE
lxml 6.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lxml" %}
-{% set version = "5.3.0" %}
+{% set version = "6.0.2" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/l/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f
+  sha256: cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:
@@ -20,7 +20,7 @@ requirements:
     - pkg-config  # [win]
   host:
     - python
-    - cython >=3.0.11
+    - cython >=3.1.4
     - libxml2 {{ libxml2 }}
     - libxslt {{ libxslt }}
     - pip


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13535](https://anaconda.atlassian.net/browse/PKG-13535)
- [Upstream repository](https://github.com/lxml/lxml/tree/lxml-6.0.2)
- [Upstream changelog/diff](https://github.com/lxml/lxml/releases)
- Relevant dependency PRs:
  - `lxml` ➡️  `xmlsec` for python 3.14

### Explanation of changes:

- Bump version number
- Update `cython` pinning


[PKG-13535]: https://anaconda.atlassian.net/browse/PKG-13535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ